### PR TITLE
created program that reports on attr type variance

### DIFF
--- a/attr.js
+++ b/attr.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const cheerio = require('cheerio');
+
+const xmldir = 'C:\\Users\\Marcus\\projects\\work\\plazi\\zenodeo\\data\\treatmentsDump';
+const xmlfiles = fs.readdirSync(xmldir);
+
+// Sets the tags to be searched. As we'w
+const tagsToSearch = ['subSubSection', 'mods:name']
+
+let i = 0; 
+let j = tagsToSearch.length;
+
+let resultingHash = {}
+
+
+for (; i < j; i++) {
+    const xml = fs.readFileSync(path.join(xmldir, `${xmlfiles[i]}`), 'utf8');
+    const $ = cheerio.load(xml, {
+        normalizeWhitespace: true,
+        xmlMode: true
+    });
+
+    // Creating a cheerio object. The && e.type === 'tag' in the filter conditions is not entirely necessary
+    // I kept it there just to guarantee that we're not looking at anything spurious.
+    $('*')
+        .contents()
+        .filter((i, e) => { return (e.name === 'mods:name' || e.name == 'subSubSection') && e.type === 'tag' })
+        .map((i, e) => {
+
+            // Composes the desired display of the key: <tag attr="value">
+            // As we're always looking for a "type" attribute, e.attribs.type works just fine.
+            let composedKey = `<${e.name} type="${e.attribs.type}">`
+            resultingHash[ composedKey ] = resultingHash[ composedKey ] ? resultingHash[ composedKey ] + 1 : 1;
+
+        });
+}
+
+let fileContent = 'tag+attr="type"\tfrequency\n'
+
+Object.keys(resultingHash).sort().forEach(e => {
+    fileContent += `${e}\t${resultingHash[e]}\n`
+})
+
+fs.writeFileSync('reports/variance-on-attr-type.txt', fileContent, 'utf8');


### PR DESCRIPTION
Hi Puneet, 

This commit has my attr.js program that creates a report on all values for the attribute "type" in the two tags that Zenodeo currently search this attr., "subSubSection" and "mods:name". It saves it in a *.txt separated by tabs. Here's an example on how it looks like:

```
tag+attr="type"	frequency
<mods:name type="personal">	4750
<subSubSection type="additional limnonectes">	1
<subSubSection type="additional material examined">	1
<subSubSection type="affinities">	1
<subSubSection type="associations">	1
<subSubSection type="basionym">	2
```

I don't know how you'll incorporate this into the index.js, but perhaps we could make a function out of this that takes an *.xml as argument, or a cheerio object. Then you could simply call it within your iteration (of the +290k treatments).

If you want me to make these modifications (to create a function), just let me know.